### PR TITLE
Use tlsSettings instead of defaultTlsSettings

### DIFF
--- a/Web/Scotty/TLS.hs
+++ b/Web/Scotty/TLS.hs
@@ -14,15 +14,14 @@ import           Control.Monad.IO.Class      (MonadIO (liftIO))
 import           Network.Wai                 (Response)
 import           Network.Wai.Handler.Warp    (Port, defaultSettings,
                                               setPort)
-import           Network.Wai.Handler.WarpTLS (certFile, defaultTlsSettings,
-                                              keyFile, runTLS, TLSSettings(..))
+import           Network.Wai.Handler.WarpTLS (runTLS, tlsSettings, TLSSettings(..))
 import           Web.Scotty                  (scottyApp, ScottyM)
 import           Web.Scotty.Trans            (ScottyT, scottyAppT)
 
 -- | Run a Scotty application over TLS
 scottyTLS :: Port -> FilePath -> FilePath -> ScottyM () -> IO ()
 scottyTLS port key cert = runTLS
-  (defaultTlsSettings { keyFile = key , certFile = cert })
+  (tlsSettings cert key)
   (setPort port defaultSettings) <=< scottyApp
 
 scottyTLSSettings :: Port -> TLSSettings -> ScottyM () -> IO ()
@@ -33,6 +32,6 @@ scottyTLSSettings port settings = runTLS
 scottyTTLS :: (Monad m, MonadIO n) => Port -> FilePath -> FilePath ->
               (m Response -> IO Response) -> ScottyT t m () -> n ()
 scottyTTLS port key cert runToIO s = scottyAppT runToIO s >>= liftIO . runTLS
-                                              (defaultTlsSettings { keyFile = key, certFile = cert })
+                                              (tlsSettings cert key)
                                               (setPort port defaultSettings)
 

--- a/scotty-tls.cabal
+++ b/scotty-tls.cabal
@@ -20,7 +20,7 @@ library
   build-depends:       base >=4.3.1 && < 5,
                        scotty >=0.10.0,
                        warp >= 1.3.4.1,
-                       warp-tls >=1.4.1.4,
+                       warp-tls >= 3.1.0,
                        wai >= 1.3.0.1,
                        transformers >= 0.3.0.0
   GHC-options: -Wall -fno-warn-orphans


### PR DESCRIPTION
warp-tls-3.3.0 made a breaking change removing `certFile` and `keyFile` ([changelog](https://hackage.haskell.org/package/warp-tls-3.3.0/changelog)).

This commit uses the [`tlsSettings`](https://hackage.haskell.org/package/warp-tls-3.3.0/docs/Network-Wai-Handler-WarpTLS.html#v:tlsSettings) smart constructor instead, which is available since [warp-tls-3.1.0](https://hackage.haskell.org/package/warp-tls-3.1.0/docs/Network-Wai-Handler-WarpTLS.html) (which came out 5 years ago).

Note that I did not get the chance to test this yet, just made sure it compiled against warp-tls-3.3.0.