### PR TITLE
Bump version 0.4.1 --> 0.4.2

### DIFF
--- a/scotty-tls.cabal
+++ b/scotty-tls.cabal
@@ -1,5 +1,5 @@
 name:                scotty-tls
-version:             0.4.1
+version:             0.4.2
 synopsis:            TLS for Scotty
 description:         Run your Scotty apps over TLS
 homepage:            https://github.com/dmjio/scotty-tls.git


### PR DESCRIPTION
The [hackage](https://hackage.haskell.org/package/scotty-tls) package for this is out of date and changes have since been merged.