### PR TITLE
use tlsSettings to construct TLSSettings follow warp-tls-3.4.3

### DIFF
--- a/Web/Scotty/TLS.hs
+++ b/Web/Scotty/TLS.hs
@@ -14,7 +14,8 @@ import           Control.Monad.IO.Class      (MonadIO (liftIO))
 import           Network.Wai                 (Response)
 import           Network.Wai.Handler.Warp    (Port, defaultSettings,
                                               setPort)
-import           Network.Wai.Handler.WarpTLS (runTLS, tlsSettings, TLSSettings(..))
+import           Network.Wai.Handler.WarpTLS (defaultTlsSettings, tlsSettings,
+                                              runTLS, TLSSettings(..))
 import           Web.Scotty                  (scottyApp, ScottyM)
 import           Web.Scotty.Trans            (ScottyT, scottyAppT)
 


### PR DESCRIPTION
since `keyFile` and `certFile` have been removed in the module Network.Wai.Handler.WarpTLS of warp-tls v3.4.3,
use tlsSettings to construct TLSSettings